### PR TITLE
fix: deprecated option in layer doc

### DIFF
--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -272,7 +272,7 @@ deptrac:
               value: src/Domain/.*
           must_not:
             - type: layer
-              layer: SubDomain
+              value: SubDomain
 ```
 
 ## `method` Collector


### PR DESCRIPTION
Fix documentation about the layer collector. `LayerCollector::satisfy` only accept `value` in `$config.`