### PR TITLE
composer-dependency-analyser: update to 1.5.0 (support functions)

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -7,4 +7,4 @@ $config = new Configuration();
 
 return $config
     ->addPathToScan(__DIR__ . '/bin/deptrac', isDev: false)
-    ->ignoreErrorsOnPath(__DIR__ . '/tests', [ErrorType::UNKNOWN_CLASS]); // keep ability to test invalid symbols
+    ->ignoreErrorsOnPath(__DIR__ . '/tests', [ErrorType::UNKNOWN_CLASS, ErrorType::UNKNOWN_FUNCTION]); // keep ability to test invalid symbols

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "phpunit/phpunit": "^10.2",
         "rector/rector": "^0.15.17",
         "roave/infection-static-analysis-plugin": "^1.28",
-        "shipmonk/composer-dependency-analyser": "^1.2",
+        "shipmonk/composer-dependency-analyser": "^1.5",
         "symfony/stopwatch": "^6.4",
         "vimeo/psalm": "^5.13"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd12787f915c79fa68567402eb2fbf87",
+    "content-hash": "43a2f2bbed0bd4647a8890f0d59d6db7",
     "packages": [
         {
             "name": "composer/pcre",
@@ -5042,16 +5042,16 @@
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/composer-dependency-analyser.git",
-                "reference": "da787b1ec7e02e618f080e65f944a72a47a4696c"
+                "reference": "da9eb497b1c7aac8fcc20e8f6a1364c4ad2ad110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/da787b1ec7e02e618f080e65f944a72a47a4696c",
-                "reference": "da787b1ec7e02e618f080e65f944a72a47a4696c",
+                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/da9eb497b1c7aac8fcc20e8f6a1364c4ad2ad110",
+                "reference": "da9eb497b1c7aac8fcc20e8f6a1364c4ad2ad110",
                 "shasum": ""
             },
             "require": {
@@ -5062,6 +5062,8 @@
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.3.0",
                 "ergebnis/composer-normalize": "^2.19",
+                "ext-dom": "*",
+                "ext-libxml": "*",
                 "phpstan/phpstan": "^1.10.63",
                 "phpstan/phpstan-phpunit": "^1.1.1",
                 "phpstan/phpstan-strict-rules": "^1.2.3",
@@ -5099,9 +5101,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/composer-dependency-analyser/issues",
-                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/1.4.0"
+                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/1.5.0"
             },
-            "time": "2024-03-19T15:39:35+00:00"
+            "time": "2024-04-11T06:43:04+00:00"
         },
         {
             "name": "spatie/array-to-xml",
@@ -5889,5 +5891,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
- [composer-dependency-analyser 1.5.0](https://github.com/shipmonk-rnd/composer-dependency-analyser/releases/tag/1.5.0)
- one function was reported in _/tests_: https://github.com/shipmonk-rnd/composer-dependency-analyser/actions/runs/8597227651/job/23555458951?pr=71