### PR TITLE
LayerCollector: better message for BC break change

### DIFF
--- a/src/Core/Layer/Collector/LayerCollector.php
+++ b/src/Core/Layer/Collector/LayerCollector.php
@@ -26,7 +26,7 @@ final class LayerCollector implements CollectorInterface
     public function satisfy(array $config, TokenReferenceInterface $reference): bool
     {
         if (!isset($config['value']) || !is_string($config['value'])) {
-            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration('LayerCollector needs the layer configuration.');
+            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration('LayerCollector needs the layer configuration, expected \'value\' config is missing or invalid.');
         }
         $layer = $config['value'];
 


### PR DESCRIPTION
This changed from 'layer' to 'value' in 2.0