### PR TITLE
Add sortByName to FileInputCollector

### DIFF
--- a/src/Core/InputCollector/FileInputCollector.php
+++ b/src/Core/InputCollector/FileInputCollector.php
@@ -63,7 +63,8 @@ final class FileInputCollector implements InputCollectorInterface
                 ->followLinks()
                 ->ignoreUnreadableDirs()
                 ->ignoreVCS(true)
-                ->notPath($this->excludedFilePatterns);
+                ->notPath($this->excludedFilePatterns)
+                ->sortByName();
 
             $customFilterIterator = $finder->getIterator();
         } catch (LogicException|DirectoryNotFoundException $exception) {


### PR DESCRIPTION
Solution to [issue#1433](https://github.com/qossmic/deptrac/issues/1433)
Sorting by name ensures same order of layers in generated dot files.