### PR TITLE
Fix: Private collectors no longer working

### DIFF
--- a/src/Core/Analyser/EventHandler/DependsOnPrivateLayer.php
+++ b/src/Core/Analyser/EventHandler/DependsOnPrivateLayer.php
@@ -27,7 +27,7 @@ class DependsOnPrivateLayer implements ViolationCreatingInterface
         $ruleset = $event->getResult();
 
         foreach ($event->dependentLayers as $dependentLayer => $isPublic) {
-            if ($event->dependerLayer === $dependentLayer && !$isPublic) {
+            if ($event->dependerLayer !== $dependentLayer && !$isPublic) {
                 $this->eventHelper->addSkippableViolation($event, $ruleset, $dependentLayer, $this);
                 $event->stopPropagation();
             }

--- a/tests/Core/Analyser/EventHandler/DependsOnPrivateLayerTest.php
+++ b/tests/Core/Analyser/EventHandler/DependsOnPrivateLayerTest.php
@@ -13,7 +13,6 @@ use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\Layer\LayerProvider;
 use Qossmic\Deptrac\Contract\Result\Violation;
-use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnInternalToken;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnPrivateLayer;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
@@ -60,17 +59,17 @@ final class DependsOnPrivateLayerTest extends TestCase
         $handler->invoke($event);
 
         $this->assertCount(
-            0, 
+            0,
             $event->getResult()->rules(),
             'No violations should be added when dependent layer is public'
         );
-        
+
         $this->assertFalse(
             $event->isPropagationStopped(),
             'Propagation should continue if dependent layer is public'
         );
     }
-    
+
     public function testPropagationContinuesWhenPrivateLayerDependsOnItself(): void
     {
         $helper = new EventHelper([], new LayerProvider([]));
@@ -125,7 +124,7 @@ final class DependsOnPrivateLayerTest extends TestCase
             $violations,
             'Violation should be added when depending on private layer'
         );
-        
+
         $rule = array_values($violations)[0];
         $this->assertSame(
             'DependerLayer',

--- a/tests/Core/Analyser/EventHandler/DependsOnPrivateLayerTest.php
+++ b/tests/Core/Analyser/EventHandler/DependsOnPrivateLayerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Analyser\EventHandler;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Analyser\EventHelper;
+use Qossmic\Deptrac\Contract\Analyser\ProcessEvent;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
+use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Contract\Layer\LayerProvider;
+use Qossmic\Deptrac\Contract\Result\Violation;
+use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnInternalToken;
+use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnPrivateLayer;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
+use Qossmic\Deptrac\Core\Dependency\Dependency;
+
+final class DependsOnPrivateLayerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $subscribedEvents = DependsOnPrivateLayer::getSubscribedEvents();
+
+        self::assertCount(1, $subscribedEvents);
+        self::assertArrayHasKey(ProcessEvent::class, $subscribedEvents);
+        self::assertSame(['invoke', -3], $subscribedEvents[ProcessEvent::class]);
+    }
+
+    private function makeEvent(
+        string $dependerLayer, string $dependentLayer, bool $isPublic
+    ): ProcessEvent {
+        $dependerToken = ClassLikeToken::fromFQCN('DependerClass');
+        $dependentToken = ClassLikeToken::fromFQCN('DependentClass');
+
+        return new ProcessEvent(
+            new Dependency(
+                $dependerToken,
+                $dependentToken,
+                new DependencyContext(new FileOccurrence('test', 1), DependencyType::STATIC_METHOD)
+            ),
+            new ClassLikeReference($dependerToken, ClassLikeType::TYPE_CLASS, [], [], []),
+            $dependerLayer,
+            new ClassLikeReference($dependentToken, ClassLikeType::TYPE_CLASS, [], [], []),
+            [$dependentLayer => $isPublic],
+            new AnalysisResult()
+        );
+    }
+
+    public function testNoViolationsWhenDependentLayerIsPublic(): void
+    {
+        $helper = new EventHelper([], new LayerProvider([]));
+        $handler = new DependsOnPrivateLayer($helper);
+
+        $event = $this->makeEvent('DependerLayer', 'DependentLayer', true);
+        $handler->invoke($event);
+
+        $this->assertCount(
+            0, 
+            $event->getResult()->rules(),
+            'No violations should be added when dependent layer is public'
+        );
+        
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if dependent layer is public'
+        );
+    }
+    
+    public function testPropagationContinuesWhenPrivateLayerDependsOnItself(): void
+    {
+        $helper = new EventHelper([], new LayerProvider([]));
+        $handler = new DependsOnPrivateLayer($helper);
+
+        $event = $this->makeEvent('LayerA', 'LayerA', false);
+        $handler->invoke($event);
+
+        $this->assertCount(
+            0,
+            $event->getResult()->rules(),
+            'No violations should be added when private layer depends on itself'
+        );
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if private layer depends on itself'
+        );
+    }
+
+    public function testPropagationContinuesWhenPublicLayerDependsOnItself(): void
+    {
+        $helper = new EventHelper([], new LayerProvider([]));
+        $handler = new DependsOnPrivateLayer($helper);
+
+        $event = $this->makeEvent('layerA', 'layerA', true);
+        $handler->invoke($event);
+
+        $this->assertCount(
+            0,
+            $event->getResult()->rules(),
+            'No violations should be added when public layer depends on itself'
+        );
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if public layer depends on itself'
+        );
+    }
+
+    public function testPropagationStoppedWhenDependingOnPrivateLayer(): void
+    {
+        $helper = new EventHelper([], new LayerProvider([]));
+        $handler = new DependsOnPrivateLayer($helper);
+
+        $event = $this->makeEvent('DependerLayer', 'DependentLayer', false);
+        $handler->invoke($event);
+
+        $violations = $event->getResult()->rules()[Violation::class] ?? [];
+        $this->assertCount(
+            1,
+            $violations,
+            'Violation should be added when depending on private layer'
+        );
+        
+        $rule = array_values($violations)[0];
+        $this->assertSame(
+            'DependerLayer',
+            $rule->getDependerLayer(),
+        );
+        $this->assertSame(
+            'DependentLayer',
+            $rule->getDependentLayer(),
+        );
+        $this->assertSame(
+            'DependsOnPrivateLayer',
+            $rule->ruleName(),
+        );
+
+        $this->assertTrue(
+            $event->isPropagationStopped(),
+            'Propagation should stop if depending on private layer'
+        );
+    }
+}


### PR DESCRIPTION
PR and tests to fix qossmic/deptrac#1435.

---

The [`private: true` collector](https://qossmic.github.io/deptrac/collectors/#extra-collector-configuration) would allow us to do that really easily, but it seems to have stopped working.

We can see in the [PR that added private collectors](https://github.com/qossmic/deptrac/pull/905/files#diff-e9502a67d3bef5407b7fb6b7c8cb17ed6c4c8940502c030d9bfc62e6126b6126) the dependency would be allowed if:
- The dependent layer is _not public_
- The dependent layer __does not equal__ the depender layer

```php
!$isPublic && $dependerLayer !== $dependentLayer
```

However, this logic seems to have been changed when the [violations were improved](https://github.com/qossmic/deptrac/pull/1105/files#diff-efa7f34c2779810259ccd7158c42347c8fa29881977c5b0c3390c13229a34493), now it will allow the dependency if:
- The dependent layer is _not public_
- The dependent lawyer __equals__ the depender layer

```php
$event->dependerLayer === $dependentLayer && !$isPublic
```