### PR TITLE
chore: Improve DX with docker

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -5,3 +5,8 @@ RUN pecl install xdebug \
     && pecl clear-cache
 WORKDIR /var/www/deptrac
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+RUN git config --global --add safe.directory /var/www/deptrac
+COPY ./docker/php/overrides.ini "$PHP_INI_DIR/conf.d/90-dev-overrides.ini"
+
+CMD ["bash"]

--- a/docker/php/overrides.ini
+++ b/docker/php/overrides.ini
@@ -1,0 +1,2 @@
+; Disable memory limit to allow infection to run
+memory_limit = -1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,6 +20,18 @@ your merge request can be accepted.
 - [Composer](https://getcomposer.org/)
 - `make`
 
+### Using Docker Compose
+
+If preferred, you can use Docker to get a development environment up and
+running quickly.
+
+- [Install Docker](https://www.docker.com/get-started/)
+- Run `docker compose run deptrac`
+
+This will build and run a local Docker image with all the necessary system
+dependencies. You can now run all the following commands from within the
+container.
+
 ## Installing tools
 
 You can install all tools needed for developing Deptrac using the Makefile by


### PR DESCRIPTION
While working on #69, there were a few small changes I needed to make to successfully run all the required CI tools under the provided docker image. 

1. Infection hits the memory limit
2. The build requires the git repository to be marked as safe
3. Setting "bash" as the `CMD` saves a few keystrokes when getting into the docker container

I've also added some docs to CONTRIBUTING.md explaining how to use the container.