### PR TITLE
[DRAFT] ComposerCollector: adding new parameters `include` and `includeDev` to separate the list of packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor/*
 coverage/*
 tools/

--- a/baseline.xml
+++ b/baseline.xml
@@ -29,17 +29,6 @@
       <code><![CDATA[!$configuration['must_not']]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
-  <file src="src/Core/Layer/Collector/ComposerFilesParser.php">
-    <InvalidReturnStatement>
-      <code>$lockedPackages</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[array<string, array{
-     *     autoload?: array{'psr-0'?: array<string, string>, 'psr-4'?: array<string, string>},
-     *     autoload-dev?: array{'psr-0'?: array<string, string>, 'psr-4'?: array<string, string>},
-     * }>]]></code>
-    </InvalidReturnType>
-  </file>
   <file src="src/Core/Layer/Collector/DirectoryCollector.php">
     <ArgumentTypeCoercion>
       <code>$validatedPattern</code>

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -128,7 +128,7 @@ The `composer` collector allows you to define dependencies on composer `require`
  - That your `require-dev` dependencies are only used in you non-production code (like DB migrations or SA tools)
  - That your code does not use any transitive dependencies (dependencies on packages installed only because your `composer.json` required packages depend on them themselves)
  - That some packages are only used in particular layers
-
+### TODO Change docs after review!
 ```yaml
 deptrac:
   layers:

--- a/src/Contract/Config/Collector/ComposerConfig.php
+++ b/src/Contract/Config/Collector/ComposerConfig.php
@@ -15,14 +15,16 @@ final class ComposerConfig extends CollectorConfig
     private function __construct(
         private readonly string $composerPath,
         private readonly string $composerLockPath,
+        private readonly bool $include,
+        private readonly bool $includeDev,
     ) {}
 
     /**
      * @param list<string> $packages
      */
-    public static function create(string $composerPath = 'composer.json', string $composerLockPath = 'composer.lock', array $packages = []): self
+    public static function create(string $composerPath = 'composer.json', string $composerLockPath = 'composer.lock', array $packages = [], bool $include = true, bool $includeDev = true): self
     {
-        $result = new self($composerPath, $composerLockPath);
+        $result = new self($composerPath, $composerLockPath, $include, $includeDev);
         foreach ($packages as $package) {
             $result->addPackage($package);
         }
@@ -41,6 +43,8 @@ final class ComposerConfig extends CollectorConfig
      *     composerPath: string,
      *     composerLockPath: string,
      *     packages: list<string>,
+     *     include: bool,
+     *     includeDev: bool,
      *     private: bool,
      *     type: string}
      */
@@ -50,6 +54,8 @@ final class ComposerConfig extends CollectorConfig
             'composerPath' => $this->composerPath,
             'composerLockPath' => $this->composerLockPath,
             'packages' => $this->packages,
+            'include' => $this->include,
+            'includeDev' => $this->includeDev,
             'private' => $this->private,
             'type' => $this->collectorType->value,
         ];

--- a/tests/Core/Layer/Collector/ComposerCollectorTest.php
+++ b/tests/Core/Layer/Collector/ComposerCollectorTest.php
@@ -27,6 +27,8 @@ final class ComposerCollectorTest extends TestCase
                 'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
                 'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
                 'packages' => ['phpstan/phpdoc-parser'],
+                'include' => true,
+                'includeDev' => true,
             ],
             'PHPStan\\PhpDocParser\\Ast\\Attribute',
             true,
@@ -36,8 +38,43 @@ final class ComposerCollectorTest extends TestCase
                 'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
                 'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
                 'packages' => ['phpstan/phpdoc-parser'],
+                'include' => true,
+                'includeDev' => true,
             ],
             'Completely\\Wrong\\Namespace\\Attribute',
+            false,
+        ];
+        yield [
+            [
+                'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
+                'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
+                'packages' => ['friendsofphp/php-cs-fixer'],
+                'include' => true,
+                'includeDev' => true,
+            ],
+            'PhpCsFixer\\FileReader',
+            true,
+        ];
+        yield [
+            [
+                'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
+                'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
+                'packages' => [],
+                'include' => false,
+                'includeDev' => true,
+            ],
+            'PhpCsFixer\\Config',
+            true,
+        ];
+        yield [
+            [
+                'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
+                'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
+                'packages' => [],
+                'include' => true,
+                'includeDev' => false,
+            ],
+            'PhpCsFixer\\Config',
             false,
         ];
     }
@@ -64,6 +101,7 @@ final class ComposerCollectorTest extends TestCase
                 'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
                 'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
                 'packages' => ['fake_package'],
+                'includeDev' => true
             ],
             new ClassLikeReference(ClassLikeToken::fromFQCN(''), ClassLikeType::TYPE_CLASS),
         );


### PR DESCRIPTION
Hello! Linked issue - [Add a setting to separate packages from require and require-dev sections for Composer collector](https://github.com/qossmic/deptrac/issues/1438).

The `packages` parameter becomes optional and acts as an additional filter for the composer packages.

Example config:
```
deptrac:
  layers:
    - name: ComposerWithoutDev
      collectors:
        - type: composer
          composerPath: composer.json
          composerLockPath: composer.lock
          includeDev: false
     - name: ComposerOnlyDev
       collectors:
         - type: composer
           composerPath: composer.json
           composerLockPath: composer.lock
           include: false
           includeDev: true
      - name: ComposerCheckSomeDeps
         collectors:
           - type: composer
             composerPath: composer.json
             composerLockPath: composer.lock
             packages: [ "some/package-from-non-dev-section" ]
             include: true
             includeDev: false
```

I kept backward compatibility and added tests.

What do you think about `include` and `includeDev` naming?